### PR TITLE
Anyurl requests timeout and user-agent config.ini option.

### DIFF
--- a/config.ini.sample
+++ b/config.ini.sample
@@ -11,3 +11,6 @@ directed_triggers = False
 autojoin = #bot_lab
 autoload = base config debug perms plugin
 superuser = Jeff!jkent@localhost
+
+[anyurl]
+user-agent = Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36

--- a/pybot/plugins/anyurl.py
+++ b/pybot/plugins/anyurl.py
@@ -48,7 +48,12 @@ class Plugin(BasePlugin):
         headers = {
             'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36'
         }
-        r = requests.get(url, stream=True, headers=headers)
+
+        try:
+            r = requests.get(url, stream=True, headers=headers, timeout=10)
+        except requests.exceptions.ReadTimeout as e:
+            msg.reply('URL Timeout')
+            return
 
         content_type, params = cgi.parse_header(r.headers['Content-Type'])
         if not content_type in content_types:

--- a/pybot/plugins/anyurl.py
+++ b/pybot/plugins/anyurl.py
@@ -45,8 +45,13 @@ class Plugin(BasePlugin):
     
     @hook
     def any_url(self, msg, domain, url):
+        try:
+            user_agent = self.bot.config.get(self.name, 'user-agent')
+        except:
+            user_agent = 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36'
+
         headers = {
-            'User-Agent': 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36'
+            'User-Agent': user_agent 
         }
 
         try:


### PR DESCRIPTION
Set a timeout for requests, so when a web page does not respond the bot does not hang.

To make setting the user-agent string easier make it a config.ini option for anyurl. If not configured it will fallback to the default value.